### PR TITLE
Removing classpath entry from jar to let this be friendly to Java API users

### DIFF
--- a/schemacrawler-db2/pom.xml
+++ b/schemacrawler-db2/pom.xml
@@ -27,9 +27,6 @@
         <configuration>
           <archive>
             <index>true</index>
-            <manifest>
-              <addClasspath>true</addClasspath>
-            </manifest>
             <manifestEntries>
               <Project>${project.name}, ${project.version}</Project>
               <Author>Sualeh Fatehi, sualeh@hotmail.com</Author>

--- a/schemacrawler-hsqldb/pom.xml
+++ b/schemacrawler-hsqldb/pom.xml
@@ -52,9 +52,6 @@
         <configuration>
           <archive>
             <index>true</index>
-            <manifest>
-              <addClasspath>true</addClasspath>
-            </manifest>
             <manifestEntries>
               <Project>${project.name}, ${project.version}</Project>
               <Author>Sualeh Fatehi, sualeh@hotmail.com</Author>

--- a/schemacrawler-mysql/pom.xml
+++ b/schemacrawler-mysql/pom.xml
@@ -32,9 +32,6 @@
         <configuration>
           <archive>
             <index>true</index>
-            <manifest>
-              <addClasspath>true</addClasspath>
-            </manifest>
             <manifestEntries>
               <Project>${project.name}, ${project.version}</Project>
               <Author>Sualeh Fatehi, sualeh@hotmail.com</Author>

--- a/schemacrawler-offline/pom.xml
+++ b/schemacrawler-offline/pom.xml
@@ -50,9 +50,6 @@
         <configuration>
           <archive>
             <index>true</index>
-            <manifest>
-              <addClasspath>true</addClasspath>
-            </manifest>
             <manifestEntries>
               <Project>${project.name}, ${project.version}</Project>
               <Author>Sualeh Fatehi, sualeh@hotmail.com</Author>

--- a/schemacrawler-oracle/pom.xml
+++ b/schemacrawler-oracle/pom.xml
@@ -27,9 +27,6 @@
         <configuration>
           <archive>
             <index>true</index>
-            <manifest>
-              <addClasspath>true</addClasspath>
-            </manifest>
             <manifestEntries>
               <Project>${project.name}, ${project.version}</Project>
               <Author>Sualeh Fatehi, sualeh@hotmail.com</Author>

--- a/schemacrawler-postgresql/pom.xml
+++ b/schemacrawler-postgresql/pom.xml
@@ -30,9 +30,6 @@
         <configuration>
           <archive>
             <index>true</index>
-            <manifest>
-              <addClasspath>true</addClasspath>
-            </manifest>
             <manifestEntries>
               <Project>${project.name}, ${project.version}</Project>
               <Author>Sualeh Fatehi, sualeh@hotmail.com</Author>

--- a/schemacrawler-sqlite/pom.xml
+++ b/schemacrawler-sqlite/pom.xml
@@ -45,9 +45,6 @@
         <configuration>
           <archive>
             <index>true</index>
-            <manifest>
-              <addClasspath>true</addClasspath>
-            </manifest>
             <manifestEntries>
               <Project>${project.name}, ${project.version}</Project>
               <Author>Sualeh Fatehi, sualeh@hotmail.com</Author>

--- a/schemacrawler-sqlserver/pom.xml
+++ b/schemacrawler-sqlserver/pom.xml
@@ -36,9 +36,6 @@
         <configuration>
           <archive>
             <index>true</index>
-            <manifest>
-              <addClasspath>true</addClasspath>
-            </manifest>
             <manifestEntries>
               <Project>${project.name}, ${project.version}</Project>
               <Author>Sualeh Fatehi, sualeh@hotmail.com</Author>


### PR DESCRIPTION
I found that the manifest was getting added to some schema crawler jars. This caused issues in adding this to the class path, esp. in conjunction with other schema crawler jars that did not have the classpath in the manifest.

If you want an executable jar, I think we should have a separate artifact/classifier created. But the default jar artifact should be friendly to use for maven/java api client users


I can put this into the regular SchemaCrawler project if you want, but at minimum, I'd like this in the Java 7 back port