### PR TITLE
Allowing schemacrawler api to be retrieved as a dependency without embedding third party l

### DIFF
--- a/schemacrawler-api/pom.xml
+++ b/schemacrawler-api/pom.xml
@@ -43,13 +43,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/schemacrawler-db2/pom.xml
+++ b/schemacrawler-db2/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/schemacrawler-dbtest/pom.xml
+++ b/schemacrawler-dbtest/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-hsqldb/pom.xml
+++ b/schemacrawler-hsqldb/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-integrations/pom.xml
+++ b/schemacrawler-integrations/pom.xml
@@ -101,15 +101,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/schemacrawler-lint/pom.xml
+++ b/schemacrawler-lint/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-mysql/pom.xml
+++ b/schemacrawler-mysql/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-offline/pom.xml
+++ b/schemacrawler-offline/pom.xml
@@ -14,7 +14,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-oracle/pom.xml
+++ b/schemacrawler-oracle/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/schemacrawler-postgresql/pom.xml
+++ b/schemacrawler-postgresql/pom.xml
@@ -14,7 +14,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-sqlite/pom.xml
+++ b/schemacrawler-sqlite/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-sqlserver/pom.xml
+++ b/schemacrawler-sqlserver/pom.xml
@@ -14,7 +14,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Followup from https://github.com/sualeh/SchemaCrawler/pull/149

We will only apply this on Java7 branch